### PR TITLE
Fix EAS channel names to match required pattern

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -31,7 +31,7 @@
         "ENVIRONMENT": "development"
       },
       "environment": "development",
-      "channel": "development:device"
+      "channel": "development-device"
     },
     "preview": {
       "extends": "production",
@@ -57,7 +57,7 @@
         "ENVIRONMENT": "preview"
       },
       "environment": "preview",
-      "channel": "preview:device"
+      "channel": "preview-device"
     },
     "production": {
       "autoIncrement": true,


### PR DESCRIPTION
Fixed invalid channel names in eas.json:
- Changed "development:device" to "development-device"
- Changed "preview:device" to "preview-device"

This fixes the pattern validation error when running eas build.