### PR TITLE
Fix wallet initialization issue by removing setupComplete persistence

### DIFF
--- a/app/models/wallet/actions/setup.ts
+++ b/app/models/wallet/actions/setup.ts
@@ -7,11 +7,6 @@ import { IWalletStore } from "../types"
 
 export async function setup(store: IWalletStore) {
   try {
-    // If setup is already complete, don't run again
-    if (store.setupComplete) {
-      return true
-    }
-
     // Get mnemonic from secure storage
     let mnemonic = await SecureStorageService.getMnemonic()
     
@@ -52,7 +47,6 @@ export async function setup(store: IWalletStore) {
 
     // Mark initialization as complete
     store.setInitialized(true)
-    store.setSetupComplete(true)
     store.setError(null)
     
     return true
@@ -60,7 +54,6 @@ export async function setup(store: IWalletStore) {
     console.error("[WalletStore] Setup error:", error)
     store.setError(error instanceof Error ? error.message : "Failed to setup wallet")
     store.setInitialized(false)
-    store.setSetupComplete(false)
     return false
   }
 }


### PR DESCRIPTION
Fixes #64 

The wallet setup function was not running on every app load because the `setupComplete` flag was being persisted. This prevented the Breez SDK from being properly initialized on subsequent app launches.

Changes:
1. Removed `setupComplete` check at start of setup function
2. Removed `setSetupComplete` calls from setup.ts
3. Kept `isInitialized` as runtime-only state

The setup function now runs on every app load, ensuring Breez SDK is properly initialized each time while still maintaining secure mnemonic storage via SecureStorageService.