### PR TITLE
Fix: Add MST observer to WalletButton for reactive balance updates

### DIFF
--- a/app/chat/drawer/WalletButton.tsx
+++ b/app/chat/drawer/WalletButton.tsx
@@ -3,12 +3,13 @@ import { MaterialCommunityIcons } from "@expo/vector-icons"
 import { useNavigation } from "@react-navigation/native"
 import { useStores } from "@/models"
 import { styles } from "./styles"
+import { observer } from "mobx-react-lite"
 
 type Props = {
   setOpen: (open: boolean) => void
 }
 
-export const WalletButton = ({ setOpen }: Props) => {
+export const WalletButton = observer(({ setOpen }: Props) => {
   const navigation = useNavigation()
   const { walletStore } = useStores()
 
@@ -25,4 +26,4 @@ export const WalletButton = ({ setOpen }: Props) => {
       </Text>
     </TouchableOpacity>
   )
-}
+})


### PR DESCRIPTION
Fixes #68

Added MST observer to WalletButton component to ensure the wallet balance display updates reactively when the underlying state changes.

Changes:
- Imported `observer` from `mobx-react-lite`
- Wrapped WalletButton component with `observer()`

This ensures that whenever `walletStore.balanceSat` changes, the UI will update accordingly.